### PR TITLE
Add format parameter and plain text return format to API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@
   - **class-WPAnyIpsumCore.php** - Exposes filters used by other classes
   - **class-WPAnyIpsumForm.php** - Shortcode for generating the form to allow visitors to generate your custom filler
   - **class-WPAnyIpsumSettings.php** - Admin settings for managing your custom filler text
-  - **class-WPAnyIpsumAPI.php** - JSON API endpoint
+  - **class-WPAnyIpsumAPI.php** - API endpoint (supports JSON and plain text)
   - **class-WPAnyIpsumOembed.php** - oEmbed endpoint
   - **class-WPAnyIpsumGenerator.php** - The WPAnyIpsumGenerator class for generating custom filler text.
 
 ## Revision History
+
+### v1.3 May 29, 2015 ###
+- API now supports a 'format' parameter to specify return format
+- 'text' return format added to return ipsum in plain text
 
 ### v1.2.3 March 27, 2015
 - Trim each word before adding it to a sentence

--- a/lib/class-WPAnyIpsumAPI.php
+++ b/lib/class-WPAnyIpsumAPI.php
@@ -42,6 +42,10 @@ if ( !class_exists( 'WPAnyIpsumAPI' ) ) {
 
 			$type = WPAnyIpsumCore::get_request( 'type' );
 			$callback = WPAnyIpsumCore::get_request( 'callback' );
+            $format = WPAnyIpsumCore::get_request( 'format' );
+            if ( !in_array($format, array( 'json', 'text' ) ) ) {
+                $format = 'json';
+            }
 
 			if ( ! empty ( $type ) || ! empty ( $callback ) ) {
 
@@ -49,12 +53,32 @@ if ( !class_exists( 'WPAnyIpsumAPI' ) ) {
 				$paras = apply_filters( 'anyipsum-generate-filler', $args );
 
 				if ( ! empty( $args['callback'] ) ) {
-					header( "Content-Type: application/javascript" );
-					echo $args['callback'] . '(' . json_encode( $paras ) . ');';
-				}
+
+                    switch ($format) {
+                        case 'plain':
+                            header( "Content-Type: text/plain" );
+                            foreach ($paras as $para) {
+                                echo $para . "\n\n";
+                            }
+                            break;
+                        default:
+                            header( "Content-Type: application/javascript" );
+                            echo $args['callback'] . '(' . json_encode( $paras ) . ');';
+                            break;
+                    }
+                }
 				else {
-					header( "Content-Type: application/json; charset=utf-8" );
-					echo json_encode( $paras );
+                    switch ( $format ) {
+                        case 'text':
+                            header( "Content-Type: text/plain" );
+                            foreach ($paras as $para) {
+                                echo $para . "\n\n";
+                            }
+                            break;
+                       default:
+                            header( "Content-Type: application/json; charset=utf-8" );
+                            echo json_encode( $paras );
+                    }
 				}
 
 				exit;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: content, ipsum
 Donate link: http://baconipsum.com/
 Requires at least: 4.0
 Tested up to: 4.2
-Stable tag: 1.2.3
+Stable tag: 1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -19,7 +19,7 @@ Includes:
 
 * [anyipsum-form] shortcode for end-users to use, fully configurable
 * custom words and filler text
-* JSON API
+* API (returns JSON or plain text)
 * oEmbed support
 
 The plugin installs Bacon Ipsum filler by default, so be sure to check Settings/Any Ipsum to fully customize your ipsum.
@@ -34,6 +34,10 @@ The plugin installs Bacon Ipsum filler by default, so be sure to check Settings/
 
 
 == Changelog ==
+
+= v1.3 May 29, 2015 =
+* API now supports a 'format' parameter to specify return format
+* 'text' return format added to return ipsum in plain text
 
 = v1.2.3 March 27, 2015 =
 * Trim each word before adding it to a sentence

--- a/wp-anyipsum.php
+++ b/wp-anyipsum.php
@@ -3,7 +3,7 @@
 Plugin Name: Any Ipsum
 Description: Roll your own custom lorem ipsum generator
 Plugin URI: https://wordpress.org/plugins/any-ipsum/
-Version: 1.2.3
+Version: 1.3
 Author: Pete Nelson <a href="https://twitter.com/GunGeekATX">(@GunGeekATX)</a>
 Text Domain: any-ipsum
 Domain Path: /lang


### PR DESCRIPTION
Keeps JSON as the default format for backward compatibility.